### PR TITLE
Support for reformatting and format on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Neovim plugin to provide syntax highlighting for `.baml` files.
 - Traditional Vim syntax highlighting.
 - Optional Tree-sitter integration for advanced highlighting.
 - Filetype detection and indentation settings.
+- Optional automatic formatting of BAML files on save using `baml-cli`.
 
 ## Installation
 
@@ -21,7 +22,7 @@ A Neovim plugin to provide syntax highlighting for `.baml` files.
      config = function()
        -- This ensures lua/baml_syntax/init.lua is run,
        -- which registers the "baml" parser and configures Tree-sitter:
-       require("baml_syntax")
+       require("baml_syntax").setup()
      end,
    }
    ```
@@ -38,7 +39,7 @@ A Neovim plugin to provide syntax highlighting for `.baml` files.
      "klepp0/nvim-baml-syntax",
      requires = { "nvim-treesitter/nvim-treesitter" },
      config = function()
-       require("baml_syntax")
+       require("baml_syntax").setup()
      end,
    }
    ```
@@ -62,7 +63,7 @@ A Neovim plugin to provide syntax highlighting for `.baml` files.
 
    ```vim
    lua << EOF
-   require("baml_syntax")
+   require("baml_syntax").setup()
    EOF
    ```
 
@@ -71,6 +72,23 @@ A Neovim plugin to provide syntax highlighting for `.baml` files.
 ## Usage
 
 Open any `.baml` file in Neovim to see syntax highlighting in action.
+
+### Formatting on save
+
+You can have BAML files get formatted on save by calling passing
+`format_on_save = true` to the `require("baml_syntax").setup()` call when you
+initialize the plugin. For example:
+
+```lua
+require("baml_syntax").setup({
+  format_on_save = true,  -- Set to true to enable formatting on save
+  baml_cli_path = "/path/to/baml-cli",  -- Optional path to baml-cli executable if it's not on PATH
+})
+```
+
+#### Commands
+
+- `:BamlFormat` - Format the current BAML file
 
 ## Contributing
 

--- a/lua/baml_syntax/init.lua
+++ b/lua/baml_syntax/init.lua
@@ -1,20 +1,89 @@
 -- lua/baml_syntax/init.lua
-local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
-parser_config.baml = {
-    install_info = {
-        url = "https://github.com/klepp0/nvim-baml-syntax",
-        files = { "parser/src/parser.c" },
-        branch = "main",
-        generate_requires_npm = false,
-        requires_generate_from_grammar = false,
-    },
-    filetype = "baml",
+local M = {}
+
+-- Default configuration
+M.config = {
+    format_on_save = false,
+    format_command = "baml-cli fmt",
 }
 
-require 'nvim-treesitter.configs'.setup {
-    ensure_installed = { "baml" },
-    highlight = {
-        enable = true,
-        additional_vim_regex_highlighting = false,
-    },
-}
+-- Function to format BAML file
+function M.format_baml(file_path)
+    file_path = file_path or vim.fn.expand('%:p')
+    
+    -- Create temporary file for output
+    local tmp_file = vim.fn.tempname()
+    
+    -- Run formatter command
+    local cmd = string.format("%s --dry-run %s > %s", M.config.format_command, vim.fn.shellescape(file_path), tmp_file)
+    local exit_code = os.execute(cmd)
+    
+    if exit_code ~= 0 then
+        vim.api.nvim_err_writeln("Error formatting BAML file")
+        return false
+    end
+    
+    -- Read formatted content
+    local formatted_content = {}
+    local file = io.open(tmp_file, "r")
+    if file then
+        for line in file:lines() do
+            table.insert(formatted_content, line)
+        end
+        file:close()
+    else
+        vim.api.nvim_err_writeln("Error reading formatted output")
+        return false
+    end
+    
+    -- Update buffer with formatted content
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, formatted_content)
+    
+    -- Clean up temporary file
+    os.remove(tmp_file)
+    return true
+end
+
+-- Setup function for user configuration
+function M.setup(opts)
+    M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+    
+    -- Register Tree-sitter parser
+    local parser_config = require("nvim-treesitter.parsers").get_parser_configs()
+    parser_config.baml = {
+        install_info = {
+            url = "https://github.com/klepp0/nvim-baml-syntax",
+            files = { "parser/src/parser.c" },
+            branch = "main",
+            generate_requires_npm = false,
+            requires_generate_from_grammar = false,
+        },
+        filetype = "baml",
+    }
+    
+    -- Configure Tree-sitter
+    require('nvim-treesitter.configs').setup {
+        ensure_installed = { "baml" },
+        highlight = {
+            enable = true,
+            additional_vim_regex_highlighting = false,
+        },
+    }
+    
+    -- Add autocmd for format on save
+    if M.config.format_on_save then
+        vim.api.nvim_create_autocmd("BufWritePre", {
+            pattern = "*.baml",
+            callback = function()
+                M.format_baml()
+            end,
+        })
+    end
+    
+    -- Create user command for manual formatting
+    vim.api.nvim_create_user_command("BamlFormat", function()
+        M.format_baml()
+    end, {})
+end
+
+return M


### PR DESCRIPTION
Baml recently added support for autoformatting of baml files in VS Code, this PR adds support for autoformatting baml files 
from within Neovim by using the baml-cli's `fmt`.

You can do `:BamlFormat` to reformat the current file, or pass `format_on_save = true` when initializing the plugin to have it format the file on save. 